### PR TITLE
Fix deprecation errors in php-7.4.0

### DIFF
--- a/src/PHPixie/Config/Storages/Type/File.php
+++ b/src/PHPixie/Config/Storages/Type/File.php
@@ -43,9 +43,9 @@ class File extends    \PHPixie\Slice\Data\Implementation
     
     protected function checkParameter(&$value)
     {
-        if($value && is_string($value) && $value{0} == '%') {
+        if($value && is_string($value) && $value[0] == '%') {
             $length = strlen($value);
-            if($value{$length - 1} == '%') {
+            if($value[$length - 1] == '%') {
                 $value = $this->parameters->getRequired(substr($value, 1, $length-2));
             }
         }


### PR DESCRIPTION
Curly braces for array or string access are deprecated and cause the
following error:
```
ErrorException: Array and string offset access syntax with curly braces is deprecated
```

Signed-off-by: Vitalii Rybalko <vilko.a@gmail.com>